### PR TITLE
Update metadata to include GNOME 47 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
   "name": "Mock Tray",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "url": "https://github.com/kra-mo/mock-tray/",
   "uuid": "mock-tray@kramo.page",


### PR DESCRIPTION
Extension still works great. Tested on Fedora 41.